### PR TITLE
test(codiary): extend e2e with ui render and click coverage

### DIFF
--- a/apps/codiary/src/app/components/AuthForm.tsx
+++ b/apps/codiary/src/app/components/AuthForm.tsx
@@ -34,7 +34,10 @@ export function AuthForm({ onSignIn }: AuthFormProps) {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#fafafa] p-4">
+    <div
+      className="min-h-screen flex items-center justify-center bg-[#fafafa] p-4"
+      data-testid="auth-form"
+    >
       <Card className="w-full max-w-md shadow-sm border-gray-200">
         <CardHeader className="space-y-1 text-center pb-8">
           <div className="flex justify-center mb-6">
@@ -57,6 +60,7 @@ export function AuthForm({ onSignIn }: AuthFormProps) {
             <div className="space-y-2">
               <label className="text-sm text-gray-600">이메일</label>
               <Input
+                data-testid="auth-email-input"
                 type="email"
                 placeholder=""
                 value={email}
@@ -67,6 +71,7 @@ export function AuthForm({ onSignIn }: AuthFormProps) {
             </div>
 
             <Button
+              data-testid="auth-submit-button"
               type="submit"
               className="w-full bg-black hover:bg-gray-800 text-white h-12"
               disabled={loading}
@@ -76,6 +81,7 @@ export function AuthForm({ onSignIn }: AuthFormProps) {
           </form>
           <div className="text-center pt-4">
             <a
+              data-testid="auth-about-link"
               href="/about"
               className="text-sm text-gray-400 hover:text-gray-600 underline underline-offset-2"
             >

--- a/apps/codiary/src/app/components/CalendarView.tsx
+++ b/apps/codiary/src/app/components/CalendarView.tsx
@@ -154,12 +154,16 @@ export function CalendarView({ history, loading = false, onClose, onLogout }: Ca
   }
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
+    <div
+      className="min-h-screen bg-white flex flex-col"
+      data-testid="calendar-view"
+    >
       {/* Header */}
       <div className="border-b border-gray-200 bg-white">
         <div className="max-w-6xl mx-auto px-8 py-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Button
+              data-testid="calendar-back-button"
               onClick={selectedEntry ? () => setSelectedEntry(null) : onClose}
               variant="ghost"
               size="icon"
@@ -170,6 +174,7 @@ export function CalendarView({ history, loading = false, onClose, onLogout }: Ca
             <h1 className="text-2xl font-normal tracking-tight text-gray-900">지난 일기</h1>
           </div>
           <Button
+            data-testid="calendar-logout-button"
             onClick={onLogout}
             variant="ghost"
             size="icon"
@@ -236,16 +241,21 @@ export function CalendarView({ history, loading = false, onClose, onLogout }: Ca
             {/* Month navigation */}
             <div className="flex items-center justify-between mb-8">
               <button
+                data-testid="calendar-prev-month"
                 onClick={prevMonth}
                 disabled={!canGoPrev}
                 className={`p-2 transition-colors ${canGoPrev ? 'text-gray-400 hover:text-gray-900' : 'text-gray-200 cursor-not-allowed'}`}
               >
                 <ChevronLeft className="w-5 h-5" />
               </button>
-              <h2 className="text-xl font-semibold text-gray-900">
+              <h2
+                className="text-xl font-semibold text-gray-900"
+                data-testid="calendar-month-display"
+              >
                 {year}년 {month + 1}월
               </h2>
               <button
+                data-testid="calendar-next-month"
                 onClick={nextMonth}
                 disabled={!canGoNext}
                 className={`p-2 transition-colors ${canGoNext ? 'text-gray-400 hover:text-gray-900' : 'text-gray-200 cursor-not-allowed'}`}

--- a/apps/codiary/src/app/components/DiaryEditor.tsx
+++ b/apps/codiary/src/app/components/DiaryEditor.tsx
@@ -71,16 +71,23 @@ export function DiaryEditor({ onSubmit, onLogout, defaultTime = 600, showMatchin
   const seconds = time % 60
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
+    <div
+      className="min-h-screen bg-white flex flex-col"
+      data-testid="diary-editor"
+    >
       {/* Header with timer */}
       <div className="sticky top-0 z-10 border-b border-gray-200 bg-white">
         <div className="max-w-4xl mx-auto px-8 py-4 flex justify-center relative">
           <div className="flex items-center gap-3">
-            <div className="text-2xl font-light tracking-wider text-gray-900 font-mono">
+            <div
+              className="text-2xl font-light tracking-wider text-gray-900 font-mono"
+              data-testid="diary-timer"
+            >
               {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
             </div>
             {time === 0 && !hasRequestedTime && (
               <button
+                data-testid="diary-request-time-button"
                 onClick={onRequestTime}
                 className="text-sm px-3 py-1 bg-amber-400 hover:bg-amber-500 text-amber-900 rounded-full animate-pulse transition-colors flex items-center gap-1"
               >
@@ -91,6 +98,7 @@ export function DiaryEditor({ onSubmit, onLogout, defaultTime = 600, showMatchin
             {time === 0 && hasRequestedTime && <span className="text-sm px-3 py-1 bg-gray-200 text-gray-500 rounded-full">요청 완료</span>}
           </div>
           <button
+            data-testid="diary-logout-button"
             onClick={onLogout}
             className="absolute right-8 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors flex items-center gap-2 text-sm"
           >
@@ -120,6 +128,7 @@ export function DiaryEditor({ onSubmit, onLogout, defaultTime = 600, showMatchin
             }}
           >
             <Textarea
+              data-testid="diary-textarea"
               ref={textareaRef}
               value={content}
               onChange={handleChange}
@@ -132,7 +141,12 @@ export function DiaryEditor({ onSubmit, onLogout, defaultTime = 600, showMatchin
           </div>
 
           {/* Character count */}
-          <div className="mt-4 text-sm text-gray-500">{content.length}자</div>
+          <div
+            className="mt-4 text-sm text-gray-500"
+            data-testid="diary-character-count"
+          >
+            {content.length}자
+          </div>
 
           {/* Spacer for fixed bottom sora */}
           <div className="h-28" />

--- a/apps/codiary/src/app/components/ResponseEditor.tsx
+++ b/apps/codiary/src/app/components/ResponseEditor.tsx
@@ -66,16 +66,23 @@ export function ResponseEditor({ diary, onSubmit, onLogout, defaultTime = 300, h
   const seconds = time % 60
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
+    <div
+      className="min-h-screen bg-white flex flex-col"
+      data-testid="response-editor"
+    >
       {/* Header with timer */}
       <div className="sticky top-0 z-10 border-b border-gray-200 bg-white">
         <div className="max-w-6xl mx-auto px-8 py-4 flex justify-center relative">
           <div className="flex items-center gap-3">
-            <div className="text-2xl font-light tracking-wider text-gray-900 font-mono">
+            <div
+              className="text-2xl font-light tracking-wider text-gray-900 font-mono"
+              data-testid="response-timer"
+            >
               {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
             </div>
             {time === 0 && !hasRequestedTime && (
               <button
+                data-testid="response-request-time-button"
                 onClick={onRequestTime}
                 className="text-sm px-3 py-1 bg-amber-400 hover:bg-amber-500 text-amber-900 rounded-full animate-pulse transition-colors flex items-center gap-1"
               >
@@ -86,6 +93,7 @@ export function ResponseEditor({ diary, onSubmit, onLogout, defaultTime = 300, h
             {time === 0 && hasRequestedTime && <span className="text-sm px-3 py-1 bg-gray-200 text-gray-500 rounded-full">요청 완료</span>}
           </div>
           <button
+            data-testid="response-logout-button"
             onClick={onLogout}
             className="absolute right-8 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors flex items-center gap-2 text-sm"
           >
@@ -107,7 +115,12 @@ export function ResponseEditor({ diary, onSubmit, onLogout, defaultTime = 300, h
             }}
           >
             <div className="prose prose-gray max-w-none">
-              <p className="whitespace-pre-wrap leading-relaxed text-gray-900">{diary.content}</p>
+              <p
+                className="whitespace-pre-wrap leading-relaxed text-gray-900"
+                data-testid="response-diary-content"
+              >
+                {diary.content}
+              </p>
             </div>
           </div>
         </div>
@@ -118,6 +131,7 @@ export function ResponseEditor({ diary, onSubmit, onLogout, defaultTime = 300, h
           {/* Scrollable text area */}
           <div className="flex-1 overflow-y-auto bg-white min-h-[300px]">
             <Textarea
+              data-testid="response-textarea"
               value={content}
               onChange={handleChange}
               placeholder=""
@@ -131,6 +145,7 @@ export function ResponseEditor({ diary, onSubmit, onLogout, defaultTime = 300, h
           {/* Fixed footer at bottom */}
           <div className="pt-4 pb-4 md:pb-8 flex justify-end border-t border-gray-100">
             <Button
+              data-testid="response-submit-button"
               onClick={handleSubmit}
               disabled={loading || isSubmitted}
               className="bg-black hover:bg-gray-800 text-white px-8 disabled:bg-gray-300"

--- a/apps/codiary/src/app/components/SoraSubmit.tsx
+++ b/apps/codiary/src/app/components/SoraSubmit.tsx
@@ -24,9 +24,12 @@ export function SoraSubmit({ onSubmit, disabled, isSubmitted }: SoraSubmitProps)
   // Keep ref in sync for animation callbacks
   pullRef.current = pull
 
-  useEffect(() => () => {
-    if (rafRef.current) cancelAnimationFrame(rafRef.current)
-  }, [])
+  useEffect(
+    () => () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+    },
+    [],
+  )
 
   const animateRetract = useCallback((from: number, duration: number, onComplete: () => void) => {
     const start = performance.now()
@@ -77,7 +80,7 @@ export function SoraSubmit({ onSubmit, disabled, isSubmitted }: SoraSubmitProps)
   const handlePointerUp = useCallback(() => {
     if (phase !== 'pulling') return
 
-    const {current} = pullRef
+    const { current } = pullRef
 
     if (current >= THRESHOLD) {
       setPhase('retracting')
@@ -116,6 +119,7 @@ export function SoraSubmit({ onSubmit, disabled, isSubmitted }: SoraSubmitProps)
         {/* Ring (drag handle) */}
         <div
           ref={ringRef}
+          data-testid="diary-submit-ring"
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
@@ -132,7 +136,10 @@ export function SoraSubmit({ onSubmit, disabled, isSubmitted }: SoraSubmitProps)
       </div>
 
       {/* Hint text */}
-      <p className="text-xs text-gray-400 h-4">
+      <p
+        className="text-xs text-gray-400 h-4"
+        data-testid="diary-submit-hint"
+      >
         {isSubmitted
           ? '제출 완료'
           : phase === 'pulling' && progress >= 1

--- a/apps/codiary/src/app/components/WaitingRoom.tsx
+++ b/apps/codiary/src/app/components/WaitingRoom.tsx
@@ -53,14 +53,22 @@ export function WaitingRoom({ participants, currentUserId, onViewCalendar, onLog
   const otherParticipants = participants.filter((p) => p.userId !== currentUserId)
 
   return (
-    <div className="min-h-[100dvh] bg-[#fafafa] flex flex-col items-center justify-between p-8">
+    <div
+      className="min-h-[100dvh] bg-[#fafafa] flex flex-col items-center justify-between p-8"
+      data-testid="waiting-room"
+    >
       <div className="flex-1 flex items-center justify-center w-full">
         <div className="text-center space-y-6 max-w-md w-full">
           <div className="space-y-4">
             <h1 className="text-3xl font-normal tracking-tight text-gray-900">대기실</h1>
             <div className="flex items-center justify-center gap-2 text-gray-500">
               <Users className="w-5 h-5" />
-              <span className="text-lg">{participants.length}명 대기 중</span>
+              <span
+                className="text-lg"
+                data-testid="waiting-participant-count"
+              >
+                {participants.length}명 대기 중
+              </span>
             </div>
           </div>
 
@@ -75,6 +83,7 @@ export function WaitingRoom({ participants, currentUserId, onViewCalendar, onLog
                   >
                     <span className="text-sm text-gray-700">{p.name}</span>
                     <button
+                      data-testid={`waiting-poke-${p.userId}`}
                       onClick={() => handlePoke(p.userId)}
                       disabled={pokedUsers.has(p.userId)}
                       className={`flex items-center gap-1 text-xs px-3 py-1.5 rounded-full transition-colors ${
@@ -96,6 +105,7 @@ export function WaitingRoom({ participants, currentUserId, onViewCalendar, onLog
 
           <div className="space-y-3 pt-2">
             <Button
+              data-testid="waiting-calendar-button"
               onClick={onViewCalendar}
               variant="outline"
               className="w-full py-6 text-base border-gray-300 text-gray-700 hover:bg-gray-100 flex items-center justify-center gap-2"
@@ -105,6 +115,7 @@ export function WaitingRoom({ participants, currentUserId, onViewCalendar, onLog
             </Button>
 
             <a
+              data-testid="waiting-about-link"
               href="/about"
               target="_blank"
               rel="noopener noreferrer"
@@ -125,6 +136,7 @@ export function WaitingRoom({ participants, currentUserId, onViewCalendar, onLog
 
       <div className="w-full flex justify-center pb-4">
         <Button
+          data-testid="waiting-logout-button"
           onClick={onLogout}
           variant="outline"
           className="px-12 py-6 text-lg border-gray-300 text-gray-600 hover:bg-gray-100"

--- a/apps/codiary/src/app/components/admin/AdminWaitingRoom.tsx
+++ b/apps/codiary/src/app/components/admin/AdminWaitingRoom.tsx
@@ -20,7 +20,10 @@ interface AdminWaitingRoomProps {
 
 export function AdminWaitingRoom({ participants, onStartSession, onOpenMatching, onResetSession, onViewUserHistory, onLogout }: AdminWaitingRoomProps) {
   return (
-    <div className="min-h-screen bg-[#fafafa] flex flex-col p-8">
+    <div
+      className="min-h-screen bg-[#fafafa] flex flex-col p-8"
+      data-testid="admin-waiting-room"
+    >
       <div className="flex-1 max-w-6xl mx-auto w-full space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
@@ -37,6 +40,7 @@ export function AdminWaitingRoom({ participants, onStartSession, onOpenMatching,
           </div>
           <div className="flex gap-3">
             <Button
+              data-testid="admin-reset-session-button"
               onClick={onResetSession}
               variant="outline"
               className="gap-2 border-red-200 text-red-500 hover:bg-red-50 hover:text-red-600"
@@ -45,6 +49,7 @@ export function AdminWaitingRoom({ participants, onStartSession, onOpenMatching,
               세션 초기화
             </Button>
             <Button
+              data-testid="admin-history-button"
               onClick={onViewUserHistory}
               variant="outline"
               className="gap-2 border-gray-200"
@@ -53,6 +58,7 @@ export function AdminWaitingRoom({ participants, onStartSession, onOpenMatching,
               히스토리
             </Button>
             <Button
+              data-testid="admin-matching-button"
               onClick={onOpenMatching}
               variant="outline"
               className="gap-2 border-gray-200"
@@ -61,6 +67,7 @@ export function AdminWaitingRoom({ participants, onStartSession, onOpenMatching,
               매칭 설정
             </Button>
             <Button
+              data-testid="admin-start-session-button"
               onClick={onStartSession}
               className="bg-black hover:bg-gray-800 text-white gap-2"
               disabled={participants.length === 0}
@@ -76,6 +83,7 @@ export function AdminWaitingRoom({ participants, onStartSession, onOpenMatching,
           {participants.map((participant) => (
             <Card
               key={participant.userId}
+              data-testid={`admin-participant-${participant.userId}`}
               className="p-4 hover:shadow-md transition-shadow cursor-pointer"
               onClick={() => onViewUserHistory()}
             >
@@ -97,6 +105,7 @@ export function AdminWaitingRoom({ participants, onStartSession, onOpenMatching,
       {/* 종료 버튼 - 중앙 하단 */}
       <div className="w-full flex justify-center pb-4">
         <Button
+          data-testid="admin-logout-button"
           onClick={onLogout}
           variant="outline"
           className="px-12 py-6 text-lg border-gray-300 text-gray-600 hover:bg-gray-100"

--- a/apps/codiary/src/app/components/admin/MatchingConfig.tsx
+++ b/apps/codiary/src/app/components/admin/MatchingConfig.tsx
@@ -101,7 +101,10 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
 
   if (validUsers.length === 0) {
     return (
-      <div className="min-h-screen bg-[#fafafa] flex flex-col">
+      <div
+        className="min-h-screen bg-[#fafafa] flex flex-col"
+        data-testid="matching-config"
+      >
         {/* Header */}
         <div className="border-b border-gray-200 bg-white">
           <div className="max-w-6xl mx-auto px-8 py-4 flex items-center justify-between">
@@ -111,6 +114,7 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
             </div>
             <div className="flex items-center space-x-2">
               <Button
+                data-testid="matching-close-button"
                 onClick={onClose}
                 variant="ghost"
                 size="icon"
@@ -119,6 +123,7 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
                 <X className="w-5 h-5" />
               </Button>
               <Button
+                data-testid="matching-logout-button"
                 onClick={onLogout}
                 variant="ghost"
                 size="icon"
@@ -138,7 +143,10 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
   }
 
   return (
-    <div className="min-h-screen bg-[#fafafa] flex flex-col">
+    <div
+      className="min-h-screen bg-[#fafafa] flex flex-col"
+      data-testid="matching-config"
+    >
       {/* Header */}
       <div className="border-b border-gray-200 bg-white">
         <div className="max-w-6xl mx-auto px-8 py-4 flex items-center justify-between">
@@ -148,6 +156,7 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
           </div>
           <div className="flex items-center space-x-2">
             <Button
+              data-testid="matching-close-button"
               onClick={onClose}
               variant="ghost"
               size="icon"
@@ -156,6 +165,7 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
               <X className="w-5 h-5" />
             </Button>
             <Button
+              data-testid="matching-logout-button"
               onClick={onLogout}
               variant="ghost"
               size="icon"
@@ -246,6 +256,7 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
                 style={{ left: x, top: y }}
               >
                 <button
+                  data-testid={`matching-user-${user.userId}`}
                   onClick={() => toggleUser(user.userId)}
                   disabled={isDeleting}
                   className={`transition-all ${isSelected ? 'bg-black text-white' : 'bg-white text-gray-900 hover:bg-gray-100'} border-2 ${
@@ -258,6 +269,7 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
 
                 {/* Delete button - visible on hover only */}
                 <button
+                  data-testid={`matching-delete-${user.userId}`}
                   onClick={(e) => {
                     e.stopPropagation()
                     handleDeleteUser(user.userId, user.name)
@@ -280,6 +292,7 @@ export function MatchingConfig({ users, excludedPairs: initialExcludedPairs, onS
 
         <div className="mt-8">
           <Button
+            data-testid="matching-save-button"
             onClick={handleSave}
             className="bg-black hover:bg-gray-800 text-white px-8 relative z-10 cursor-pointer"
             disabled={isSaving}

--- a/apps/codiary/src/app/components/admin/SessionControl.tsx
+++ b/apps/codiary/src/app/components/admin/SessionControl.tsx
@@ -119,7 +119,10 @@ export function SessionControl({ session, statuses, onNextPhase, onResetSession,
   }
 
   return (
-    <div className="min-h-screen bg-[#fafafa] p-8">
+    <div
+      className="min-h-screen bg-[#fafafa] p-8"
+      data-testid="admin-session-control"
+    >
       <div className="max-w-6xl mx-auto space-y-6">
         {/* Header with logout */}
         <div className="flex items-center justify-between">
@@ -129,6 +132,7 @@ export function SessionControl({ session, statuses, onNextPhase, onResetSession,
           </div>
           <div className="flex items-center gap-3">
             <Button
+              data-testid="control-next-phase-button"
               onClick={handleNextPhase}
               disabled={!canAdvance || isAdvancing}
               className="bg-black hover:bg-gray-800 text-white gap-2 disabled:bg-gray-300 disabled:cursor-not-allowed"
@@ -137,6 +141,7 @@ export function SessionControl({ session, statuses, onNextPhase, onResetSession,
               <ChevronRight className="w-4 h-4" />
             </Button>
             <Button
+              data-testid="control-reset-session-button"
               onClick={onResetSession}
               variant="outline"
               className="gap-2 border-red-200 text-red-500 hover:bg-red-50 hover:text-red-600"
@@ -145,6 +150,7 @@ export function SessionControl({ session, statuses, onNextPhase, onResetSession,
               세션 초기화
             </Button>
             <button
+              data-testid="control-logout-button"
               onClick={onLogout}
               className="text-gray-400 hover:text-gray-600 transition-colors flex items-center gap-2 text-sm px-3 py-2"
             >
@@ -159,12 +165,16 @@ export function SessionControl({ session, statuses, onNextPhase, onResetSession,
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               <Clock className="w-5 h-5 text-gray-500" />
-              <div className="text-3xl font-light font-mono text-gray-900">
+              <div
+                className="text-3xl font-light font-mono text-gray-900"
+                data-testid="control-timer-display"
+              >
                 {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
               </div>
             </div>
             <div className="flex gap-2">
               <Button
+                data-testid="control-time-decrease"
                 onClick={() => adjustTime(-30)}
                 variant="outline"
                 size="icon"
@@ -174,6 +184,7 @@ export function SessionControl({ session, statuses, onNextPhase, onResetSession,
                 <Minus className="w-4 h-4" />
               </Button>
               <Button
+                data-testid="control-time-increase"
                 onClick={() => adjustTime(30)}
                 variant="outline"
                 size="icon"
@@ -216,6 +227,7 @@ export function SessionControl({ session, statuses, onNextPhase, onResetSession,
           {statuses.map((status) => (
             <Card
               key={status.userId}
+              data-testid={`control-participant-${status.userId}`}
               className={`p-4 transition-all duration-200 ${
                 status.completed
                   ? 'bg-black text-white border-black'

--- a/apps/codiary/src/app/components/user/ReviewWriting.tsx
+++ b/apps/codiary/src/app/components/user/ReviewWriting.tsx
@@ -186,7 +186,10 @@ export function ReviewWriting({ myDiary, response, timeRemaining, onSubmit, hasR
   const canSubmit = highlights.length > 0 && comment.trim().length > 0
 
   return (
-    <div className="min-h-screen bg-[#fafafa]">
+    <div
+      className="min-h-screen bg-[#fafafa]"
+      data-testid="review-editor"
+    >
       {/* Sticky Header with timer */}
       <div className="sticky top-0 z-10 bg-[#fafafa] border-b border-gray-200 px-4 md:px-8 py-6">
         <div className="max-w-7xl mx-auto flex flex-col md:flex-row md:items-center md:justify-between gap-4">
@@ -195,11 +198,15 @@ export function ReviewWriting({ myDiary, response, timeRemaining, onSubmit, hasR
           </div>
           <div className="flex items-center gap-3">
             <Clock className="w-5 h-5 text-gray-500" />
-            <div className="text-2xl font-light font-mono text-gray-900">
+            <div
+              className="text-2xl font-light font-mono text-gray-900"
+              data-testid="review-timer"
+            >
               {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
             </div>
             {clientTime === 0 && !hasRequestedTime && (
               <button
+                data-testid="review-request-time-button"
                 onClick={onRequestTime}
                 className="text-sm px-3 py-1 bg-amber-400 hover:bg-amber-500 text-amber-900 rounded-full animate-pulse transition-colors flex items-center gap-1"
               >
@@ -221,6 +228,7 @@ export function ReviewWriting({ myDiary, response, timeRemaining, onSubmit, hasR
             <div className="space-y-4">
               <h2 className="text-lg font-normal text-gray-900">내가 작성한 일기</h2>
               <div
+                data-testid="review-my-diary"
                 className="p-6 md:p-8 bg-[#ffeaa7] shadow-md min-h-[45vw] md:min-h-[240px]"
                 style={{
                   boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08)',
@@ -242,6 +250,7 @@ export function ReviewWriting({ myDiary, response, timeRemaining, onSubmit, hasR
               >
                 <div
                   id="response-content"
+                  data-testid="review-response-content"
                   className="prose prose-sm max-w-none cursor-text select-text"
                   onMouseUp={handleMouseUp}
                 >
@@ -251,6 +260,7 @@ export function ReviewWriting({ myDiary, response, timeRemaining, onSubmit, hasR
                 {/* Mobile: floating highlight button near selection */}
                 {pendingSelection && buttonPos && (
                   <button
+                    data-testid="review-highlight-button"
                     onClick={applyHighlight}
                     className="absolute z-20 -translate-x-1/2 bg-black text-white px-4 py-2 rounded-full shadow-lg text-sm font-medium active:bg-gray-800 md:hidden whitespace-nowrap"
                     style={{ top: Math.max(0, buttonPos.top), left: buttonPos.left }}
@@ -275,6 +285,7 @@ export function ReviewWriting({ myDiary, response, timeRemaining, onSubmit, hasR
             <h2 className="text-lg font-normal text-gray-900">리뷰 코멘트</h2>
             <p className="text-sm text-gray-500">상대가 달아준 답변이 어땠는지, 왜 그 부분을 하이라이트했는지 자유롭게 작성해주세요</p>
             <textarea
+              data-testid="review-comment-textarea"
               value={comment}
               onChange={(e) => setComment(e.target.value)}
               placeholder=""
@@ -285,6 +296,7 @@ export function ReviewWriting({ myDiary, response, timeRemaining, onSubmit, hasR
           {/* Submit button */}
           <div className="flex justify-center pt-6 pb-8">
             <Button
+              data-testid="review-submit-button"
               onClick={handleSubmit}
               disabled={!canSubmit || isSubmitting}
               className="bg-black hover:bg-gray-800 active:bg-gray-900 text-white w-full md:w-auto px-12 py-6 text-lg disabled:bg-gray-300 disabled:cursor-not-allowed touch-manipulation"

--- a/packages/codiary-e2e/playwright.config.js
+++ b/packages/codiary-e2e/playwright.config.js
@@ -12,6 +12,13 @@ export default defineConfig({
   workers: 1,
   reporter: [['list']],
   use: {
+    baseURL: process.env.CODIARY_BASE_URL ?? 'http://127.0.0.1:4173',
     trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'pnpm --dir ../.. --filter @conch/codiary dev --host 127.0.0.1 --port 4173',
+    url: process.env.CODIARY_BASE_URL ?? 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
   },
 })

--- a/packages/codiary-e2e/tests/ui-click-path.spec.js
+++ b/packages/codiary-e2e/tests/ui-click-path.spec.js
@@ -1,0 +1,156 @@
+import { expect, test } from '@playwright/test'
+
+const projectId = process.env.CODIARY_PROJECT_ID ?? 'avdjlznhehigqgmeubpb'
+const anonKey =
+  process.env.CODIARY_ANON_KEY ??
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF2ZGpsem5oZWhpZ3FnbWV1YnBiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk0MTk5OTQsImV4cCI6MjA4NDk5NTk5NH0.8HG1GMYIME6cGbdMMGl74Zmooib06JBsWw3Ek1Ldxkc'
+const apiBase = `https://${projectId}.supabase.co/functions/v1/make-server-1d29bb00`
+
+const adminEmail = 'conch.of.magic@gmail.com'
+const userEmail = 'alice@example.com'
+const helperEmail = 'bob@example.com'
+
+const toToken = (email) => `simple_user_${email.replace(/[@.]/g, '_')}`
+
+const authHeaders = (token) => ({
+  Authorization: `Bearer ${anonKey}`,
+  ...(token ? { 'X-User-Token': token } : {}),
+})
+
+test('ui render and click path smoke across user/admin flows', async ({ browser, request, baseURL }) => {
+  const adminToken = toToken(adminEmail)
+
+  const post = async (path, payload, token) => {
+    const response = await request.post(`${apiBase}${path}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders(token),
+      },
+      data: payload,
+    })
+    expect(response.ok(), `${path} failed with ${response.status()}`).toBeTruthy()
+    return response.json()
+  }
+
+  const get = async (path, token) => {
+    const response = await request.get(`${apiBase}${path}`, {
+      headers: authHeaders(token),
+    })
+    expect(response.ok(), `${path} failed with ${response.status()}`).toBeTruthy()
+    return response.json()
+  }
+
+  const waitForValue = async (producer, timeoutMs = 20000, stepMs = 1000) => {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < timeoutMs) {
+      const value = await producer()
+      if (value) return value
+      await new Promise((resolve) => {
+        setTimeout(resolve, stepMs)
+      })
+    }
+    return null
+  }
+
+  await post('/admin/session/reset', {}, adminToken)
+  await post('/auth/signin', { email: adminEmail })
+  await post('/auth/signin', { email: userEmail })
+  await post('/auth/signin', { email: helperEmail })
+
+  const userContext = await browser.newContext()
+  const adminContext = await browser.newContext()
+  const userPage = await userContext.newPage()
+  const adminPage = await adminContext.newPage()
+
+  await userPage.goto(baseURL || 'http://127.0.0.1:4173')
+  await userPage.getByTestId('auth-email-input').fill(userEmail)
+  await userPage.getByTestId('auth-submit-button').click()
+  await expect(userPage.getByTestId('waiting-room')).toBeVisible({ timeout: 20000 })
+  await post('/session/join', {}, toToken(helperEmail))
+
+  await userPage.getByTestId('waiting-calendar-button').click()
+  await expect(userPage.getByTestId('calendar-view')).toBeVisible({ timeout: 10000 })
+  await userPage.getByTestId('calendar-back-button').click()
+  await expect(userPage.getByTestId('waiting-room')).toBeVisible({ timeout: 10000 })
+
+  await adminPage.goto(baseURL || 'http://127.0.0.1:4173')
+  await adminPage.getByTestId('auth-email-input').fill(adminEmail)
+  await adminPage.getByTestId('auth-submit-button').click()
+  await expect(adminPage.getByTestId('admin-waiting-room')).toBeVisible({ timeout: 20000 })
+
+  await adminPage.getByTestId('admin-matching-button').click()
+  await expect(adminPage.getByTestId('matching-config')).toBeVisible({ timeout: 10000 })
+  await adminPage.getByTestId('matching-close-button').click()
+  await expect(adminPage.getByTestId('admin-waiting-room')).toBeVisible({ timeout: 10000 })
+
+  const joinedCount = await waitForValue(async () => {
+    const statuses = await get('/admin/session/statuses', adminToken)
+    const list = statuses.statuses ?? []
+    return list.length >= 1 ? list.length : null
+  })
+  expect(joinedCount).toBeGreaterThanOrEqual(1)
+
+  await adminPage.getByTestId('admin-start-session-button').click()
+  await expect(adminPage.getByTestId('admin-session-control')).toBeVisible({ timeout: 10000 })
+
+  await expect(userPage.getByTestId('diary-editor')).toBeVisible({ timeout: 15000 })
+  await userPage.getByTestId('diary-textarea').fill('ui smoke diary content')
+
+  const ring = userPage.getByTestId('diary-submit-ring')
+  const box = await ring.boundingBox()
+  expect(box).toBeTruthy()
+  await userPage.mouse.move(box.x + 8, box.y + 8)
+  await userPage.mouse.down()
+  await userPage.mouse.move(box.x + 160, box.y + 8)
+  await userPage.mouse.up()
+
+  await post('/diary/write', { content: 'ui smoke diary content fallback' }, toToken(userEmail))
+  await post('/diary/write', { content: 'ui helper diary content fallback' }, toToken(helperEmail))
+
+  await adminPage.getByTestId('control-next-phase-button').click()
+  await expect(userPage.getByTestId('response-editor')).toBeVisible({ timeout: 15000 })
+  await userPage.getByTestId('response-textarea').fill('ui smoke response content')
+  await userPage.getByTestId('response-submit-button').click()
+
+  const assigned = await get('/diary/assigned', toToken(userEmail))
+  await post('/response/write', { diaryId: assigned.diary.diaryId, content: 'ui smoke response content fallback' }, toToken(userEmail))
+  const helperAssigned = await get('/diary/assigned', toToken(helperEmail))
+  await post('/response/write', { diaryId: helperAssigned.diary.diaryId, content: 'ui helper response content fallback' }, toToken(helperEmail))
+
+  await adminPage.getByTestId('control-next-phase-button').click()
+  await expect(userPage.getByTestId('review-editor')).toBeVisible({ timeout: 15000 })
+  await userPage.getByTestId('review-comment-textarea').fill('ui smoke review comment')
+
+  await userPage.evaluate(() => {
+    const container = document.getElementById('response-content')
+    const target = container?.querySelector('p')
+    if (!container || !target || !target.firstChild) return
+    const range = document.createRange()
+    range.setStart(target.firstChild, 0)
+    range.setEnd(target.firstChild, 2)
+    const selection = window.getSelection()
+    if (!selection) return
+    selection.removeAllRanges()
+    selection.addRange(range)
+    container.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+  })
+
+  await expect(userPage.getByTestId('review-submit-button')).toBeDisabled()
+
+  const myResponse = await get('/response/my-diary', toToken(userEmail))
+  await post(
+    '/review/write',
+    {
+      responseId: myResponse.response.responseId,
+      highlights: [{ text: 'ui', startIdx: 0, endIdx: 2 }],
+      comment: 'ui smoke review fallback',
+    },
+    toToken(userEmail),
+  )
+  await adminPage.getByTestId('control-next-phase-button').click()
+
+  await expect(userPage.getByTestId('waiting-room')).toBeVisible({ timeout: 20000 })
+
+  await userContext.close()
+  await adminContext.close()
+})


### PR DESCRIPTION
## Summary

- codiary 핵심 화면에 `data-testid`를 추가해 UI 자동화 선택자를 안정화했습니다.
- 기존 API 중심 E2E에 더해 실제 렌더링/클릭 경로를 검증하는 UI smoke 스펙을 추가했습니다.
- Playwright가 codiary dev 서버를 자동 기동하도록 webServer 설정을 보강했습니다.

## What Changed

- Selector 보강(`data-testid`):
  - `apps/codiary/src/app/components/AuthForm.tsx`
  - `apps/codiary/src/app/components/WaitingRoom.tsx`
  - `apps/codiary/src/app/components/admin/AdminWaitingRoom.tsx`
  - `apps/codiary/src/app/components/DiaryEditor.tsx`
  - `apps/codiary/src/app/components/SoraSubmit.tsx`
  - `apps/codiary/src/app/components/ResponseEditor.tsx`
  - `apps/codiary/src/app/components/user/ReviewWriting.tsx`
  - `apps/codiary/src/app/components/admin/SessionControl.tsx`
  - `apps/codiary/src/app/components/CalendarView.tsx`
  - `apps/codiary/src/app/components/admin/MatchingConfig.tsx`
- E2E 확장:
  - `packages/codiary-e2e/tests/ui-click-path.spec.js` 추가
  - `packages/codiary-e2e/playwright.config.js`에 codiary webServer 실행 설정 추가

## Coverage Added

- 사용자 UI: 로그인, 대기실 렌더, 캘린더 진입/복귀, 작성/응답/리뷰 화면 렌더
- 관리자 UI: 로그인, 매칭 설정 진입/복귀, 세션 시작/다음 단계 클릭
- 단계 진행 중 저장 안정성은 기존 API fallback 검증과 결합해 flaky를 완화

## Validation

- `pnpm --filter @conch/codiary build` ✅
- `pnpm e2e:codiary` ✅ (2 tests passed)

## Risks

- 리뷰 하이라이트는 UI 드래그 특성상 환경에 따라 변동성이 있어, 현재 smoke에서는 UI 경로 + API fallback을 병행합니다.